### PR TITLE
Adding messagekeys($enctext) method which returns recipient info

### DIFF
--- a/php_gnupg.h
+++ b/php_gnupg.h
@@ -62,6 +62,7 @@ PHP_FUNCTION(gnupg_getprotocol);
 PHP_FUNCTION(gnupg_encrypt);
 PHP_FUNCTION(gnupg_encryptsign);
 PHP_FUNCTION(gnupg_decrypt);
+PHP_FUNCTION(gnupg_messagekeys);
 PHP_FUNCTION(gnupg_decryptverify);
 PHP_FUNCTION(gnupg_export);
 PHP_FUNCTION(gnupg_import);


### PR DESCRIPTION
The return type is an associative array of keyid -> status, where status
is true if we have a secret key locally for that key or false if not. If
the provided $enctext is invalid, it returns false and sets the error
state appropriately.