### PR TITLE
gnupg.c: fix gnupg_adddecryptkey() passphrase handling

### DIFF
--- a/gnupg.c
+++ b/gnupg.c
@@ -1048,6 +1048,7 @@ PHP_FUNCTION(gnupg_adddecryptkey)
 	phpc_str_size_t passphrase_len;
 	gpgme_key_t gpgme_key;
 	gpgme_subkey_t gpgme_subkey;
+	int loopback_set = 0;
 
 	GNUPG_GETOBJ();
 
@@ -1073,6 +1074,10 @@ PHP_FUNCTION(gnupg_adddecryptkey)
 			PHPC_HASH_CSTR_ADD_PTR(
 					PHPC_THIS->decryptkeys, gpgme_subkey->keyid,
 					passphrase, passphrase_len + 1);
+			if (!loopback_set && passphrase && passphrase_len > 0) {
+				gpgme_set_pinentry_mode(PHPC_THIS->ctx, GPGME_PINENTRY_MODE_LOOPBACK);
+				loopback_set = 1;
+			}
 		}
 		gpgme_subkey = gpgme_subkey->next;
 	}


### PR DESCRIPTION
  This corrects an issue where the given passphrase was not being respected and
    pinentry was being called regardless.  This fix will set the pinentry_mode to loopback
    mode so that our custom passphrase_decrypt_cb() function will be called.