### PR TITLE
Fix configure failure on NetBSD

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -1,7 +1,7 @@
 dnl config.m4 for extension gnupg
 AC_CANONICAL_HOST
 case $host_os in
-   *BSD*)
+   *BSD* | *bsd)
         GNUPG_DL=""
         ;;
     *)


### PR DESCRIPTION
$host_os is "netbsd" (all lowercase) on NetBSD according to config.log