### PR TITLE
also cleanup socket files

### DIFF
--- a/tests/gnupgt.inc
+++ b/tests/gnupgt.inc
@@ -29,7 +29,7 @@ class gnupgt {
             return;
         }
         foreach (glob($homeDir . '/*') as $filename) {
-            if (is_file($filename)) {
+            if (!is_dir($filename)) {
                 unlink($filename);
             }
         }


### PR DESCRIPTION
Test suite may fail because of remaining files in test directory (socket from gpg-agent)

```
$ ll tests/home
srwx------. 1 extras mock 0 15 févr. 07:06 S.gpg-agent
srwx------. 1 extras mock 0 15 févr. 07:06 S.gpg-agent.browser
srwx------. 1 extras mock 0 15 févr. 07:06 S.gpg-agent.extra
srwx------. 1 extras mock 0 15 févr. 07:06 S.gpg-agent.ssh

```

So
```
========DIFF========
001+ Warning: rmdir(/builddir/build/BUILD/php-pecl-gnupg-1.5.0~RC1/NTS/tests/home): Directory not empty in /builddir/build/BUILD/php-pecl-gnupg-1.5.0~RC1/NTS/tests/gnupgt.inc on line 43
002+ 
003+ Warning: mkdir(): File exists in /builddir/build/BUILD/php-pecl-gnupg-1.5.0~RC1/NTS/tests/gnupgt.inc on line 51
========DONE========
FAIL encryptsign and decryptverify a text [tests/gnupg_oo_encryptsign.phpt] 

```