### PR TITLE
fix build with old libgpgme 1.3

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -40,15 +40,16 @@ if test "$PHP_GNUPG" != "no"; then
 
   PHP_ADD_INCLUDE($GNUPG_DIR/include)
 
+  dnl gpgme_op_passwd is not used but was added in 1.3.0
   LIBNAME=gpgme
-  LIBSYMBOL=gpgme_check_version
+  LIBSYMBOL=gpgme_op_passwd
 
   PHP_CHECK_LIBRARY($LIBNAME,$LIBSYMBOL,
   [
     PHP_ADD_LIBRARY_WITH_PATH($LIBNAME, $GNUPG_DIR/$PHP_LIBDIR, GNUPG_SHARED_LIBADD)
     AC_DEFINE(HAVE_GNUPGLIB,1,[ ])
   ],[
-    AC_MSG_ERROR([wrong gpgme lib version or lib not found])
+    AC_MSG_ERROR([wrong gpgme lib version or lib not found (version >= 1.3 required)])
   ],[
     -L$GNUPG_DIR/$PHP_LIBDIR -lm $GNUPG_DL
   ])

--- a/gnupg.c
+++ b/gnupg.c
@@ -170,7 +170,9 @@ static void php_gnupg_this_make(PHPC_THIS_DECLARE(gnupg), zval *options TSRMLS_D
 					ctx, GPGME_PROTOCOL_OpenPGP, file_name, home_dir);
 		}
 		gpgme_set_armor(ctx, 1);
+#if GPGME_VERSION_NUMBER >= 0x010400  /* GPGME >= 1.4.0 */
 		gpgme_set_pinentry_mode(ctx, GPGME_PINENTRY_MODE_LOOPBACK);
+#endif
 	}
 }
 /* }}} */
@@ -591,10 +593,8 @@ PHP_MINIT_FUNCTION(gnupg)
 #if GPGME_VERSION_NUMBER >= 0x010500  /* GPGME >= 1.5.0 */
 	PHP_GNUPG_SET_CLASS_CONST("PK_ECC",             GPGME_PK_ECC);
 #endif /* gpgme >= 1.5.0 */	
-#if GPGME_VERSION_NUMBER >= 0x010300  /* GPGME >= 1.3.0 */
 	PHP_GNUPG_SET_CLASS_CONST("PK_ECDSA",           GPGME_PK_ECDSA);
 	PHP_GNUPG_SET_CLASS_CONST("PK_ECDH",            GPGME_PK_ECDH);
-#endif /* gpgme >= 1.3.0 */	
 #if GPGME_VERSION_NUMBER >= 0x010700  /* GPGME >= 1.7.0 */
 	PHP_GNUPG_SET_CLASS_CONST("PK_EDDSA",           GPGME_PK_EDDSA);
 #endif /* gpgme >= 1.7.0 */
@@ -633,10 +633,8 @@ PHP_MINIT_FUNCTION(gnupg)
 #if GPGME_VERSION_NUMBER >= 0x010500  /* GPGME >= 1.5.0 */
 	PHP_GNUPG_REG_CONST("GNUPG_PK_ECC",             GPGME_PK_ECC);
 #endif /* gpgme >= 1.5.0 */	
-#if GPGME_VERSION_NUMBER >= 0x010300  /* GPGME >= 1.3.0 */
 	PHP_GNUPG_REG_CONST("GNUPG_PK_ECDSA",           GPGME_PK_ECDSA);
 	PHP_GNUPG_REG_CONST("GNUPG_PK_ECDH",            GPGME_PK_ECDH);
-#endif /* gpgme >= 1.3.0 */	
 #if GPGME_VERSION_NUMBER >= 0x010700  /* GPGME >= 1.7.0 */
 	PHP_GNUPG_REG_CONST("GNUPG_PK_EDDSA",           GPGME_PK_EDDSA);
 #endif /* gpgme >= 1.7.0 */
@@ -1099,9 +1097,7 @@ PHP_FUNCTION(gnupg_keyinfo)
 			PHP_GNUPG_ARRAY_ADD_ASSOC_BOOL(subkey, revoked, gpgme_subkey);
 			PHP_GNUPG_ARRAY_ADD_ASSOC_BOOL(subkey, can_certify, gpgme_subkey);
 			PHP_GNUPG_ARRAY_ADD_ASSOC_BOOL(subkey, can_authenticate, gpgme_subkey);
-#if GPGME_VERSION_NUMBER >= 0x010100  /* GPGME >= 1.1.0 */
 			PHP_GNUPG_ARRAY_ADD_ASSOC_BOOL(subkey, is_qualified, gpgme_subkey);
-#endif /* gpgme >= 1.1.0 */
 #if GPGME_VERSION_NUMBER >= 0x010900  /* GPGME >= 1.9.0 */
 			PHP_GNUPG_ARRAY_ADD_ASSOC_BOOL(subkey, is_de_vs, gpgme_subkey);
 #endif /* gpgme >= 1.9.0 */
@@ -1117,15 +1113,15 @@ PHP_FUNCTION(gnupg_keyinfo)
 				PHP_GNUPG_ARRAY_ADD_ASSOC_CSTR(subkey, keygrip, gpgme_subkey);
 			}
 #endif /* gpgme >= 1.7.0 */
-#if GPGME_VERSION_NUMBER >= 0x010200  /* GPGME >= 1.2.0 */
 			PHP_GNUPG_ARRAY_ADD_ASSOC_BOOL(subkey, is_cardkey, gpgme_subkey);
 			if (gpgme_subkey->card_number) {
 				PHP_GNUPG_ARRAY_ADD_ASSOC_CSTR(subkey, card_number, gpgme_subkey);
 			}
-#endif /* gpgme >= 1.2.0 */
+#if GPGME_VERSION_NUMBER >= 0x010403  /* GPGME >= 1.4.3 */
 			if (gpgme_subkey->curve) {
 				PHP_GNUPG_ARRAY_ADD_ASSOC_CSTR(subkey, curve, gpgme_subkey);
 			}
+#endif
 
 			PHPC_ARRAY_ADD_NEXT_INDEX_ZVAL(
 					PHPC_VAL_CAST_TO_PZVAL(subkeys),


### PR DESCRIPTION
At least on RHEL 7 which provides gpgme version 1.3.2

Build time:

`
/builddir/build/BUILD/php-pecl-gnupg-1.5.0~RC1/NTS/gnupg.c: In function 'php_gnupg_this_make':
/builddir/build/BUILD/php-pecl-gnupg-1.5.0~RC1/NTS/gnupg.c:173:3: warning: implicit declaration of function 'gpgme_set_pinentry_mode' [-Wimplicit-function-declaration]
   gpgme_set_pinentry_mode(ctx, GPGME_PINENTRY_MODE_LOOPBACK);
   ^
/builddir/build/BUILD/php-pecl-gnupg-1.5.0~RC1/NTS/gnupg.c:173:32: error: 'GPGME_PINENTRY_MODE_LOOPBACK' undeclared (first use in this function)
   gpgme_set_pinentry_mode(ctx, GPGME_PINENTRY_MODE_LOOPBACK);
                                ^
/builddir/build/BUILD/php-pecl-gnupg-1.5.0~RC1/NTS/gnupg.c:173:32: note: each undeclared identifier is reported only once for each function it appears in
/builddir/build/BUILD/php-pecl-gnupg-1.5.0~RC1/NTS/gnupg.c: In function 'zif_gnupg_keyinfo':
/builddir/build/BUILD/php-pecl-gnupg-1.5.0~RC1/NTS/gnupg.c:1126:20: error: 'struct _gpgme_subkey' has no member named 'curve'
    if (gpgme_subkey->curve) {
                    ^
In file included from /usr/include/php/main/php.h:38:0,
                 from /builddir/build/BUILD/php-pecl-gnupg-1.5.0~RC1/NTS/gnupg.c:21:
/builddir/build/BUILD/php-pecl-gnupg-1.5.0~RC1/NTS/gnupg.c:521:54: error: 'struct _gpgme_subkey' has no member named 'curve'
   PHPC_VAL_CAST_TO_PZVAL(_g_arr), #_g_name, _g_struct->_g_key)
                                                      ^
/usr/include/php/Zend/zend_API.h:388:111: note: in definition of macro 'add_assoc_string'
 #define add_assoc_string(__arg, __key, __str, __duplicate) add_assoc_string_ex(__arg, __key, strlen(__key)+1, __str, __duplicate)
                                                                                                               ^
/builddir/build/BUILD/php-pecl-gnupg-1.5.0~RC1/NTS/gnupg.c:520:2: note: in expansion of macro 'PHPC_ARRAY_ADD_ASSOC_CSTR'
  PHPC_ARRAY_ADD_ASSOC_CSTR(\
  ^
/builddir/build/BUILD/php-pecl-gnupg-1.5.0~RC1/NTS/gnupg.c:523:2: note: in expansion of macro 'PHP_GNUPG_ARRAY_ADD_ASSOC_CSTR_EX'
  PHP_GNUPG_ARRAY_ADD_ASSOC_CSTR_EX(_g_arr, _g_name, _g_struct, _g_name)
  ^
/builddir/build/BUILD/php-pecl-gnupg-1.5.0~RC1/NTS/gnupg.c:1127:5: note: in expansion of macro 'PHP_GNUPG_ARRAY_ADD_ASSOC_CSTR'
     PHP_GNUPG_ARRAY_ADD_ASSOC_CSTR(subkey, curve, gpgme_subkey);
     ^
/builddir/build/BUILD/php-pecl-gnupg-1.5.0~RC1/NTS/gnupg.c: In function 'zif_gnupg_encrypt':
/builddir/build/BUILD/php-pecl-gnupg-1.5.0~RC1/NTS/gnupg.c:505:48: warning: operation on '_phpc_this->err' may be undefined [-Wsequence-point]
 #define PHP_GNUPG_DO(_action) ((PHPC_THIS->err = _action) == GPG_ERR_NO_ERROR)
                                                ^
/builddir/build/BUILD/php-pecl-gnupg-1.5.0~RC1/NTS/gnupg.c:1445:7: note: in expansion of macro 'PHP_GNUPG_DO'
  if (!PHP_GNUPG_DO(PHPC_THIS->err = gpgme_data_new(&out))) {
       ^
`

