### PR TITLE
config.m4: Add largefile support

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -39,7 +39,9 @@ if test "$PHP_GNUPG" != "no"; then
   fi
 
   PHP_ADD_INCLUDE($GNUPG_DIR/include)
-
+  AC_SYS_LARGEFILE
+  AC_TYPE_OFF_T
+  
   LIBNAME=gpgme
   LIBSYMBOL=gpgme_check_version
 


### PR DESCRIPTION
The GPGME uses AC_SYS_LARGEFILE in its `configure.ac`, which makes it expects largefile support to be enabled when the system supports it. See the following from https://gnupg.org/documentation/manuals/gpgme/Largefile-Support-_0028LFS_0029.html:

"On POSIX platforms you can enable largefile support, if it is different from the default on the system the application is compiled on, by using the Autoconf macro AC_SYS_LARGEFILE. If you do this, then you don’t need to worry about anything else: It will just work. In this case you might also want to use AC_FUNC_FSEEKO to take advantage of some new interfaces, and AC_TYPE_OFF_T (just in case)."

Adding this is required on 32-bits and optional on 64-bits platforms.