### PR TITLE
Fix GH-37: decryption of an encrypted empty string returns false

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@ List of all features for the release
 
 ## X.Y.Z
 - The deletekey `allow_secret` made optional again
+- Fixed GH-37: `gnupg_decrypt()` returns false when decrypting an encrypted empty string
 
 ## 1.5.1
 - Fixed compilation with PHP 8.1

--- a/gnupg.c
+++ b/gnupg.c
@@ -1705,11 +1705,13 @@ PHP_FUNCTION(gnupg_decrypt)
 		return;
 	}
 	userret = gpgme_data_release_and_get_mem(out, &ret_size);
+
 	gpgme_data_release(in);
-	PHPC_CSTRL_RETVAL(userret, ret_size);
-	free(userret);
-	if (ret_size < 1) {
-		RETVAL_FALSE;
+	if (userret != NULL) {
+		PHPC_CSTRL_RETVAL(userret, ret_size);
+		free(userret);
+	} else {
+		PHPC_CSTR_EMPTY_RETVAL();
 	}
 }
 /* }}} */

--- a/tests/gnupg_oo_encrypt_empty_str.phpt
+++ b/tests/gnupg_oo_encrypt_empty_str.phpt
@@ -1,0 +1,26 @@
+--TEST--
+encrypt and decrypt a text
+--SKIPIF--
+<?php if(!class_exists("gnupg")) die("skip"); ?>
+--FILE--
+<?php
+require_once "gnupgt.inc";
+gnupgt::import_key();
+
+$gpg = new gnupg();
+$gpg->seterrormode(gnupg::ERROR_WARNING);
+$gpg->addencryptkey($fingerprint);
+$enc = $gpg->encrypt("");
+
+$gpg = new gnupg();
+$gpg->adddecryptkey($fingerprint, $passphrase);
+$ret = $gpg->decrypt($enc);
+var_dump($ret);
+?>
+--EXPECTF--
+string(0) ""
+--CLEAN--
+<?php
+require_once "gnupgt.inc";
+gnupgt::delete_key();
+?>


### PR DESCRIPTION
This fixes GH-37 and related memory leak.