### PR TITLE
missing in pecl archive

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -96,6 +96,7 @@
     <file name="gnupg_res_sign_normal.phpt" role="test" />
     <file name="gnupg_res_sign_normal_noarmor.phpt" role="test" />
     <file name="gnupgt.inc" role="test" />
+    <file name="no_uid_hint_msg.gpg" role="test" />
     <file name="vars.inc" role="test" />
    </dir>
   </dir>


### PR DESCRIPTION
Running test suite from pecl archive
```

========DIFF========
001+ Warning: file_get_contents(/dev/shm/BUILD/php-pecl-gnupg-1.5.2-build/php-pecl-gnupg-1.5.2/gnupg-1.5.2/tests/no_uid_hint_msg.gpg): Failed to open stream: No such file or directory in /dev/shm/BUILD/php-pecl-gnupg-1.5.2-build/php-pecl-gnupg-1.5.2/gnupg-1.5.2/tests/gnupg_oo_decrypt_no_uid_hint.php on line 80
     bool(false)
     Array
     (
004-     [generic_message] => No user ID hint
005-     [gpgme_code] => 1
006-     [gpgme_source] => Unspecified source
007-     [gpgme_message] => General error
005+     [generic_message] => decrypt failed
006+     [gpgme_code] => 117440570
007+     [gpgme_source] => GPGME
008+     [gpgme_message] => No data
     )
========DONE========
FAIL decrypt with private key without uid hint [tests/gnupg_oo_decrypt_no_uid_hint.phpt] 

```