### PR TITLE
fix tests with  5.6

### DIFF
--- a/tests/gnupgt.inc
+++ b/tests/gnupgt.inc
@@ -75,7 +75,7 @@ class gnupgt {
         self::reset_key();
 
         $gpg = self::create_instance();
-        $gpg->import($privkey ?? $testkey);
+        $gpg->import(is_null($privkey) ? $testkey : $privkey);
     }
 
     /**


### PR DESCRIPTION
As PHP 5.x is still supported according to packahe.xml

Build OK and test suite OK
