### PR TITLE
clean hidden files

### DIFF
--- a/tests/gnupgt.inc
+++ b/tests/gnupgt.inc
@@ -90,9 +90,10 @@ class gnupgt {
         if (!is_dir($homeDir)) {
             return;
         }
-        foreach (glob($homeDir . '/*') as $filename) {
-            if (!is_dir($filename)) {
-                unlink($filename);
+        $dir = opendir($homeDir);
+        while ($filename = readdir($dir)) {
+            if (!is_dir("$homeDir/$filename")) {
+                unlink("$homeDir/$filename");
             }
         }
         $privKeyDir = self::get_priv_key_dir($homeDir);


### PR DESCRIPTION
Using the **GnuPG v1** home directory may contain hidden files (e.g. `.gpg-v21-migrated`) not retrieved by glob.
