### PR TITLE
use zend_ce_exception instead of zend_exception_get_default() for 8.5

### DIFF
--- a/gnupg.c
+++ b/gnupg.c
@@ -64,7 +64,7 @@ PHPC_OBJ_DEFINE_HANDLER_VAR(gnupg);
 				break; \
 			case 2: \
 				zend_throw_exception(\
-					zend_exception_get_default(TSRMLS_C), \
+					zend_ce_exception, \
 					(char*) error, \
 					0 TSRMLS_CC \
 				); \
@@ -169,7 +169,7 @@ static void php_gnupg_this_make(PHPC_THIS_DECLARE(gnupg), zval *options TSRMLS_D
 			if (gpgme_ctx_set_engine_info(
 					ctx, GPGME_PROTOCOL_OpenPGP, file_name, home_dir) != GPG_ERR_NO_ERROR) {
 				zend_throw_exception(
-					zend_exception_get_default(TSRMLS_C),
+					zend_ce_exception,
 					(char*) "Setting engine info failed",
 					0 TSRMLS_CC
 				);

--- a/gnupg_keylistiterator.c
+++ b/gnupg_keylistiterator.c
@@ -201,7 +201,7 @@ PHP_METHOD(gnupg_keylistiterator, rewind)
 
 	if ((PHPC_THIS->err = gpgme_op_keylist_start(
 			 PHPC_THIS->ctx, PHPC_THIS->pattern ? PHPC_THIS->pattern : "", 0)) != GPG_ERR_NO_ERROR){
-		zend_throw_exception(zend_exception_get_default(TSRMLS_C), (char *)gpg_strerror(PHPC_THIS->err), 1 TSRMLS_CC);
+		zend_throw_exception(zend_ce_exception, (char *)gpg_strerror(PHPC_THIS->err), 1 TSRMLS_CC);
 	}
 	if ((PHPC_THIS->err = gpgme_op_keylist_next(PHPC_THIS->ctx, &PHPC_THIS->gpgkey)) != GPG_ERR_NO_ERROR){
 		RETURN_FALSE;


### PR DESCRIPTION
* `zend_ce_exception` available since 7.0
* `zend_exception_get_default` removed in 8.5

NOTICE: This PR drops support for PHP 5 (still supported according to package.xml)