### PR TITLE
Support compiling against GPGME 2.0.0

### DIFF
--- a/gnupg.c
+++ b/gnupg.c
@@ -341,7 +341,9 @@ phpc_function_entry gnupg_methods[] = {
 	PHP_GNUPG_FALIAS(addencryptkey,     arginfo_gnupg_key_method)
 	PHP_GNUPG_FALIAS(adddecryptkey,     arginfo_gnupg_key_passphrase_method)
 	PHP_GNUPG_FALIAS(deletekey,         arginfo_gnupg_deletekey_method)
+#if GPGME_VERSION_NUMBER < 0x020000  /* GPGME < 2.0.0 */
 	PHP_GNUPG_FALIAS(gettrustlist,      arginfo_gnupg_pattern_method)
+#endif
 	PHP_GNUPG_FALIAS(listsignatures,    arginfo_gnupg_keyid_method)
 	PHP_GNUPG_FALIAS(seterrormode,      arginfo_gnupg_errmode_method)
 	PHPC_FE_END
@@ -483,7 +485,9 @@ static zend_function_entry gnupg_functions[] = {
 	PHP_FE(gnupg_addencryptkey,		arginfo_gnupg_key_function)
 	PHP_FE(gnupg_adddecryptkey,		arginfo_gnupg_key_passphrase_function)
 	PHP_FE(gnupg_deletekey,			arginfo_gnupg_deletekey_function)
+#if GPGME_VERSION_NUMBER < 0x020000  /* GPGME < 2.0.0 */
 	PHP_FE(gnupg_gettrustlist,		arginfo_gnupg_pattern_function)
+#endif
 	PHP_FE(gnupg_listsignatures,	arginfo_gnupg_keyid_function)
 	PHP_FE(gnupg_seterrormode,		arginfo_gnupg_errmode_function)
 	PHPC_FE_END
@@ -1936,6 +1940,8 @@ PHP_FUNCTION(gnupg_deletekey)
 }
 /* }}} */
 
+#if GPGME_VERSION_NUMBER < 0x020000  /* GPGME < 2.0.0 */
+
 /* {{{ proto array gnupg_gettrustlist(string pattern)
 * searching for trust items which match PATTERN
 */
@@ -1980,6 +1986,8 @@ PHP_FUNCTION(gnupg_gettrustlist)
 	}
 }
 /* }}} */
+
+#endif /* GPGME < 2.0.0 */
 
 /* {{{ proto array gnupg_listsignatures(string keyid) */
 PHP_FUNCTION(gnupg_listsignatures)


### PR DESCRIPTION
This change allows the extension to successfully compile against the recently released [GPGME 2.0.0](https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gpgme.git;a=blob;f=NEWS;h=cd0e093bf83fe47b6773fb478fced07d8409fbe0;hb=gpgme-2.0.0), which removed the `trustlist` feature, using some simple `#if GPGME_VERSION_NUMBER` checks.

Note: I also saw that my tests failed locally due to a newline. I'm not sure why it had a newline before; none of the other plaintexts tests do, so I didn't yet commit a fix for it since I don't know if it would break tests when compiling against older versions of GPGME. Fixed locally by updating the testcase:

```diff
diff --git a/tests/gnupg_oo_sign_clear.phpt b/tests/gnupg_oo_sign_clear.phpt
index 4f9b79c..05fda25 100644
--- a/tests/gnupg_oo_sign_clear.phpt
+++ b/tests/gnupg_oo_sign_clear.phpt
@@ -38,8 +38,7 @@ array(1) {
     int(0)
   }
 }
-string(8) "foo bar
-"
+string(7) "foo bar"
 --CLEAN--
 <?php
 require_once "gnupgt.inc";
diff --git a/tests/gnupg_res_sign_clear.phpt b/tests/gnupg_res_sign_clear.phpt
index 71dd6c2..74fd26d 100644
--- a/tests/gnupg_res_sign_clear.phpt
+++ b/tests/gnupg_res_sign_clear.phpt
@@ -36,8 +36,7 @@ array(1) {
     int(0)
   }
 }
-string(8) "foo bar
-"
+string(7) "foo bar"
 --CLEAN--
 <?php
 require_once "gnupgt.inc";
```

Other than that change, tests run successfully.

There were also some added features in the new release, but I've opted to keep this change at a minimum and leave adding functionality for later.