### PR TITLE
Add PIE support (GH-56)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,32 @@ jobs:
       - name: Run tests
         run: |
           make test
+
+  pie-install:
+    runs-on: ubuntu-24.04
+    env:
+      PIE_VERSION: "1.4.8"
+
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gpg gpgsm libgpgme-dev php-cli php-dev autoconf libtool make gcc
+
+      - name: Checkout php-gnupg
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Download pie.phar
+        run: |
+          curl -fsSL -o pie.phar \
+            "https://github.com/php/pie/releases/download/${PIE_VERSION}/pie.phar"
+
+      - name: Install php-gnupg with PIE
+        # PIE builds as the current user and auto-elevates with sudo (passwordless
+        # in GitHub Actions) only for the final install step.
+        run: php pie.phar install
+
+      - name: Verify the extension is loaded
+        run: php -m | grep -qx gnupg

--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ is supported is 1.3.0. The extension supports GnuPG version 1 and 2.
 
 Of course PHP has to be installed too. The minimal version that is supported is 5.3.2.
 
+#### PIE
+
+This extension can be installed with [PIE](https://github.com/php/pie), the modern
+successor to PECL.
+
+```
+$ pie install php-gnupg/gnupg
+```
+
 #### PECL
 
 This extension is available on PECL.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,34 @@
+{
+    "name": "php-gnupg/gnupg",
+    "description": "A wrapper around the GpgME library that provides access to GnuPG.",
+    "type": "php-ext",
+    "license": "BSD-2-Clause",
+    "keywords": ["gnupg", "gpg", "gpgme", "encryption", "signing", "extension"],
+    "homepage": "https://github.com/php-gnupg/php-gnupg",
+    "support": {
+        "issues": "https://github.com/php-gnupg/php-gnupg/issues",
+        "source": "https://github.com/php-gnupg/php-gnupg",
+        "docs": "https://www.php.net/manual/en/book.gnupg.php"
+    },
+    "require": {
+        "php": "^7.2 || ^8.0"
+    },
+    "php-ext": {
+        "extension-name": "gnupg",
+        "support-zts": true,
+        "support-nts": true,
+        "os-families-exclude": ["windows"],
+        "configure-options": [
+            {
+                "name": "with-gnupg",
+                "description": "Include gnupg support, optionally specifying the path to the GpgME installation (directory containing include/gpgme.h)",
+                "needs-value": true
+            },
+            {
+                "name": "with-gpg",
+                "description": "Path to the gpg v1.x binary",
+                "needs-value": true
+            }
+        ]
+    }
+}


### PR DESCRIPTION
## Summary

Closes #56.

Adds a `composer.json` so the extension can be installed with [PIE](https://github.com/php/pie), the modern replacement for PECL:

```bash
pie install php-gnupg/gnupg
```

## Details

- `type` is set to `php-ext` as required by PIE for a PHP module.
- Package name is `php-gnupg/gnupg` (must differ from any regular PHP package name, per the PIE docs).
- `extension-name` is `gnupg`.
- `configure-options` mirror the flags in `config.m4` (`--with-gnupg`, `--with-gpg`), both taking a value.
- `os-families-exclude: ["windows"]` since Windows is not supported (no PHP-compatible GpgME builds), matching the README.
- The `phpc` git submodule is not referenced by any build file (only `gnupg.c` and `gnupg_keylistiterator.c` are compiled), so PIE's default git-archive download builds fine without it.
- README documents the new PIE install method.

`composer validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)